### PR TITLE
Add custom conversion adapter support to ason

### DIFF
--- a/src/main/java/com/afollestad/ason/AsonAdapter.java
+++ b/src/main/java/com/afollestad/ason/AsonAdapter.java
@@ -1,0 +1,13 @@
+package com.afollestad.ason;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({FIELD})
+public @interface AsonAdapter {
+  Class<? extends AsonSerializerAdapter> value();
+}

--- a/src/main/java/com/afollestad/ason/AsonSerializerAdapter.java
+++ b/src/main/java/com/afollestad/ason/AsonSerializerAdapter.java
@@ -1,0 +1,7 @@
+package com.afollestad.ason;
+
+public abstract class AsonSerializerAdapter<T> {
+  public abstract T fromJson(String json);
+
+  public abstract String toJson(T value);
+}

--- a/src/main/java/com/afollestad/ason/ClassCacheEntry.java
+++ b/src/main/java/com/afollestad/ason/ClassCacheEntry.java
@@ -21,12 +21,14 @@ class ClassCacheEntry<T> {
   private final Constructor<?> ctor;
   private final HashMap<String, Field> fieldMap;
   private final HashMap<String, Class<?>> listGenericTypeMap;
+  private final HashMap<String, Class<? extends AsonSerializerAdapter>> adapterHashMap;
 
   ClassCacheEntry(Class<T> cls, boolean recursive) {
     this.cls = cls;
     this.fieldMap = new HashMap<>(4);
     this.ctor = getDefaultConstructor(cls);
     this.listGenericTypeMap = new HashMap<>(0);
+    this.adapterHashMap = new HashMap<>(0);
     invalidateFields(recursive);
   }
 
@@ -45,6 +47,10 @@ class ClassCacheEntry<T> {
       if (field.getType() == List.class) {
         listGenericTypeMap.put(name, listGenericType(field));
       }
+      AsonAdapter adapterAnnotation = field.getAnnotation(AsonAdapter.class);
+      if (adapterAnnotation != null) {
+        adapterHashMap.put(name, adapterAnnotation.value());
+      }
     }
   }
 
@@ -61,6 +67,10 @@ class ClassCacheEntry<T> {
 
   Class<?> listItemType(String fieldName) {
     return listGenericTypeMap.get(fieldName);
+  }
+
+  Class<? extends AsonSerializerAdapter> adapterType(String fieldName) {
+    return adapterHashMap.get(fieldName);
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/com/afollestad/ason/AsonAdapterTest.java
+++ b/src/test/java/com/afollestad/ason/AsonAdapterTest.java
@@ -1,0 +1,56 @@
+package com.afollestad.ason;
+
+import static junit.framework.TestCase.assertEquals;
+
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AsonAdapterTest {
+
+  private SerializationAdapterTest test;
+
+  @Before
+  public void setup() {
+    test = new SerializationAdapterTest();
+    test.uuid = UUID.randomUUID();
+  }
+
+  @Test
+  public void test_adapter() {
+    Ason serialized = Ason.serialize(test);
+    assertEquals(serialized.get("uuid"), test.uuid.toString());
+    SerializationAdapterTest deserialized =
+        Ason.deserialize(serialized, SerializationAdapterTest.class);
+    assertEquals(test, deserialized);
+  }
+
+  private static class SerializationAdapterTest {
+    @AsonAdapter(UUIDAdapter.class)
+    public UUID uuid;
+
+    public String string = "Test";
+
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof SerializationAdapterTest) {
+        SerializationAdapterTest compare = (SerializationAdapterTest) o;
+        return Objects.equals(compare.uuid, uuid) && Objects.equals(compare.string, string);
+      }
+      return false;
+    }
+  }
+
+  public static class UUIDAdapter extends AsonSerializerAdapter<UUID> {
+    @Override
+    public UUID fromJson(String json) {
+      return UUID.fromString(json);
+    }
+
+    @Override
+    public String toJson(UUID value) {
+      return value.toString();
+    }
+  }
+}


### PR DESCRIPTION
With regrets I've seen that you have deprecated this project, however I'd still like to have this little feature I coded upstreamed to the official version, only if you have the time to look over my code and merge it of course :)

The changes implement some sort of Adapter mechanism to the (De-)Serializer like Gson already does, but in an imho much better way, using annotations on the serialized classes.

**Commit message:**
It is now possible to annotate fields in your Java classes with
@AsonAdapter and a reference to your conversion class extending
AsonSerializerAdapter to have ason apply the toJson() and fromJson()
methods instead of plain casting when (de-)serializing objects
of that class.